### PR TITLE
Install systemd unit under libdir, not sysconfdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,7 @@ nss_tlsd_service = configure_file(input: 'nss-tlsd.service.in',
                                   output: 'nss-tlsd.service',
                                   configuration: cfg)
 install_data(nss_tlsd_service,
-             install_dir: join_paths(get_option('sysconfdir'),
+             install_dir: join_paths(get_option('libdir'),
                                      'systemd',
                                      'system'))
 


### PR DESCRIPTION
`nss-tlsd.service` should be installed in `/usr/lib/systemd/system`, not `/etc/systemd/system`.