### PR TITLE
Allow specifying socket

### DIFF
--- a/nss-tls.c
+++ b/nss-tls.c
@@ -65,9 +65,9 @@ enum nss_status _nss_tls_gethostbyname2_r(const char *name,
     *errnop = ENOENT;
     *h_errnop = NETDB_SUCCESS;
 
-    const char *const socketpath = getenv ("NSS_TLS_SOCKET");
+    const char *const socketpath = getenv("NSS_TLS_SOCKET");
 
-    if (!socketpath) {
+    if (!socketpath || getuid() != geteuid()) {
         if (geteuid() == 0)
             strcpy(sun.sun_path, NSS_TLS_SOCKET_PATH);
         else {

--- a/nss-tlsd.c
+++ b/nss-tlsd.c
@@ -76,6 +76,7 @@ static struct {
 } resolvers[MAX_RESOLVERS];
 gint32 nresolvers = 0;
 
+static char *socketpath;
 static gboolean cache = FALSE;
 static gboolean randomize = FALSE;
 static GHashTable *caches[2] = {NULL, NULL};
@@ -943,7 +944,8 @@ static GOptionEntry opts[] = {
         &randomize,
         "Choose a random server every time",
         NULL
-    }
+    },
+    {"socket", 's', 0, G_OPTION_ARG_FILENAME, &socketpath, "Socket to listen for requests", NULL}
 };
 
 static
@@ -973,7 +975,7 @@ main (int    argc,
     GSocketAddress *sa;
     const gchar *runtime_dir;
     struct passwd *user;
-    gchar *user_socket = root_socket;
+    gchar *user_socket;
 #ifdef NSS_TLS_DEBUG
     static SoupLogger *logger;
 #endif
@@ -1011,7 +1013,13 @@ main (int    argc,
         }
 
         mode = 0666;
-    } else {
+    }
+
+    if (socketpath)
+        user_socket = socketpath;
+    else if (root)
+        user_socket = root_socket;
+    else {
         runtime_dir = g_get_user_runtime_dir ();
         if (!runtime_dir) {
             return EXIT_FAILURE;


### PR DESCRIPTION
This allows running multiple daemons. The plugin uses the NSS_TLS_SOCKET environment variable to find the socket.